### PR TITLE
Use Command/Output pattern directly for new SDK methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,6 +711,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "strata-concurrency"
 version = "0.5.1"
+source = "git+https://github.com/stratadb-labs/strata-core?branch=main#e5994d0bbf258b94fcc158b08446cda2a39c3e80"
 dependencies = [
  "chrono",
  "dashmap",
@@ -727,6 +728,7 @@ dependencies = [
 [[package]]
 name = "strata-core"
 version = "0.5.1"
+source = "git+https://github.com/stratadb-labs/strata-core?branch=main#e5994d0bbf258b94fcc158b08446cda2a39c3e80"
 dependencies = [
  "bincode",
  "chrono",
@@ -739,6 +741,7 @@ dependencies = [
 [[package]]
 name = "strata-durability"
 version = "0.5.1"
+source = "git+https://github.com/stratadb-labs/strata-core?branch=main#e5994d0bbf258b94fcc158b08446cda2a39c3e80"
 dependencies = [
  "crc32fast",
  "parking_lot",
@@ -757,6 +760,7 @@ dependencies = [
 [[package]]
 name = "strata-engine"
 version = "0.5.1"
+source = "git+https://github.com/stratadb-labs/strata-core?branch=main#e5994d0bbf258b94fcc158b08446cda2a39c3e80"
 dependencies = [
  "base64",
  "byteorder",
@@ -780,6 +784,7 @@ dependencies = [
 [[package]]
 name = "strata-executor"
 version = "0.5.1"
+source = "git+https://github.com/stratadb-labs/strata-core?branch=main#e5994d0bbf258b94fcc158b08446cda2a39c3e80"
 dependencies = [
  "base64",
  "rmp-serde",
@@ -797,6 +802,7 @@ dependencies = [
 [[package]]
 name = "strata-intelligence"
 version = "0.5.1"
+source = "git+https://github.com/stratadb-labs/strata-core?branch=main#e5994d0bbf258b94fcc158b08446cda2a39c3e80"
 dependencies = [
  "dashmap",
  "serde",
@@ -809,6 +815,7 @@ dependencies = [
 [[package]]
 name = "strata-security"
 version = "0.5.1"
+source = "git+https://github.com/stratadb-labs/strata-core?branch=main#e5994d0bbf258b94fcc158b08446cda2a39c3e80"
 dependencies = [
  "serde",
 ]
@@ -816,6 +823,7 @@ dependencies = [
 [[package]]
 name = "strata-storage"
 version = "0.5.1"
+source = "git+https://github.com/stratadb-labs/strata-core?branch=main#e5994d0bbf258b94fcc158b08446cda2a39c3e80"
 dependencies = [
  "dashmap",
  "rustc-hash",
@@ -826,6 +834,7 @@ dependencies = [
 [[package]]
 name = "stratadb"
 version = "0.5.1"
+source = "git+https://github.com/stratadb-labs/strata-core?branch=main#e5994d0bbf258b94fcc158b08446cda2a39c3e80"
 dependencies = [
  "serde_json",
  "strata-executor",


### PR DESCRIPTION
## Summary

- Fix SDK methods to use the executor Command/Output pattern directly instead of calling removed wrapper methods on the Strata API
- Aligns with how MCP and CLI handle operations - SDKs should use the Command enum directly
- Fixes build failure caused by strata-core revert (PR #1038)

Methods fixed to use `executor.execute(Command::...)`:
- `state_delete` → `Command::StateDelete`
- `state_list` → `Command::StateList`
- `kv_list_paginated` → `Command::KvList` (with cursor/limit)
- `event_list_paginated` → `Command::EventGetByType` (with limit/after)
- `vector_search_filtered` → `Command::VectorSearch` (with filter/metric)
- `space_create` → `Command::SpaceCreate`
- `space_exists` → `Command::SpaceExists`
- `search` → `Command::Search`

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` passes
- [ ] Manual testing with Python bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)