### PR TITLE
Remove config params from open(), use CONFIG SET/GET

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -61,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -79,9 +85,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -97,9 +103,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -241,6 +247,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,10 +296,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -342,6 +376,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +389,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -378,19 +420,25 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.181"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.182"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libredox"
@@ -400,14 +448,14 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
- "redox_syscall 0.7.1",
+ "redox_syscall 0.7.2",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -588,6 +636,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
+checksum = "6d94dd2f7cd932d4dc02cc8b2b50dfd38bd079a4e5d79198b99743d7fcf9a4b4"
 dependencies = [
  "bitflags",
 ]
@@ -759,9 +817,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -772,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "log",
  "once_cell",
@@ -816,6 +874,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -907,7 +971,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 [[package]]
 name = "strata-concurrency"
 version = "0.6.0"
-source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#07f1bb56a224544dcd19d064bf8b1a4cd5e19764"
+source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#5d73c8fe0dbaad90ece2c363add37b1e21c27811"
 dependencies = [
  "chrono",
  "dashmap",
@@ -924,7 +988,7 @@ dependencies = [
 [[package]]
 name = "strata-core"
 version = "0.6.0"
-source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#07f1bb56a224544dcd19d064bf8b1a4cd5e19764"
+source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#5d73c8fe0dbaad90ece2c363add37b1e21c27811"
 dependencies = [
  "bincode",
  "chrono",
@@ -937,7 +1001,7 @@ dependencies = [
 [[package]]
 name = "strata-durability"
 version = "0.6.0"
-source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#07f1bb56a224544dcd19d064bf8b1a4cd5e19764"
+source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#5d73c8fe0dbaad90ece2c363add37b1e21c27811"
 dependencies = [
  "crc32fast",
  "fs2",
@@ -957,7 +1021,7 @@ dependencies = [
 [[package]]
 name = "strata-engine"
 version = "0.6.0"
-source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#07f1bb56a224544dcd19d064bf8b1a4cd5e19764"
+source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#5d73c8fe0dbaad90ece2c363add37b1e21c27811"
 dependencies = [
  "base64 0.21.7",
  "byteorder",
@@ -985,7 +1049,7 @@ dependencies = [
 [[package]]
 name = "strata-executor"
 version = "0.6.0"
-source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#07f1bb56a224544dcd19d064bf8b1a4cd5e19764"
+source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#5d73c8fe0dbaad90ece2c363add37b1e21c27811"
 dependencies = [
  "base64 0.21.7",
  "chrono",
@@ -1005,7 +1069,7 @@ dependencies = [
 [[package]]
 name = "strata-inference"
 version = "0.6.0"
-source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#07f1bb56a224544dcd19d064bf8b1a4cd5e19764"
+source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#5d73c8fe0dbaad90ece2c363add37b1e21c27811"
 dependencies = [
  "thiserror",
  "tracing",
@@ -1015,7 +1079,7 @@ dependencies = [
 [[package]]
 name = "strata-intelligence"
 version = "0.6.0"
-source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#07f1bb56a224544dcd19d064bf8b1a4cd5e19764"
+source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#5d73c8fe0dbaad90ece2c363add37b1e21c27811"
 dependencies = [
  "once_cell",
  "strata-core",
@@ -1027,7 +1091,7 @@ dependencies = [
 [[package]]
 name = "strata-search"
 version = "0.6.0"
-source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#07f1bb56a224544dcd19d064bf8b1a4cd5e19764"
+source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#5d73c8fe0dbaad90ece2c363add37b1e21c27811"
 dependencies = [
  "rayon",
  "serde",
@@ -1040,7 +1104,7 @@ dependencies = [
 [[package]]
 name = "strata-security"
 version = "0.6.0"
-source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#07f1bb56a224544dcd19d064bf8b1a4cd5e19764"
+source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#5d73c8fe0dbaad90ece2c363add37b1e21c27811"
 dependencies = [
  "serde",
 ]
@@ -1048,7 +1112,7 @@ dependencies = [
 [[package]]
 name = "strata-storage"
 version = "0.6.0"
-source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#07f1bb56a224544dcd19d064bf8b1a4cd5e19764"
+source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#5d73c8fe0dbaad90ece2c363add37b1e21c27811"
 dependencies = [
  "dashmap",
  "rustc-hash",
@@ -1059,7 +1123,7 @@ dependencies = [
 [[package]]
 name = "stratadb"
 version = "0.6.0"
-source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#07f1bb56a224544dcd19d064bf8b1a4cd5e19764"
+source = "git+https://github.com/strata-ai-labs/strata-core?branch=main#5d73c8fe0dbaad90ece2c363add37b1e21c27811"
 dependencies = [
  "serde_json",
  "strata-executor",
@@ -1086,9 +1150,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.115"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e614ed320ac28113fa64972c4262d5dbc89deacdfd00c34a3e4cea073243c12"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1212,15 +1276,21 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unindent"
@@ -1271,11 +1341,11 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "js-sys",
  "serde_core",
  "sha1_smol",
@@ -1304,10 +1374,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.108"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1318,9 +1397,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1328,9 +1407,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1341,11 +1420,45 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -1534,6 +1647,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "xattr"

--- a/python/stratadb/__init__.py
+++ b/python/stratadb/__init__.py
@@ -582,8 +582,7 @@ def setup():
     """Download model files for auto-embedding.
 
     Downloads MiniLM-L6-v2 model files (~80MB) to ~/.stratadb/models/minilm-l6-v2/.
-    Called automatically when ``auto_embed=True`` is passed to ``Strata.open()``,
-    but can be called explicitly to pre-download during installation.
+    Can be called explicitly to pre-download during installation.
 
     Returns:
         The path where model files are stored.
@@ -632,22 +631,18 @@ class Strata:
     # -- Construction (static) ------------------------------------------------
 
     @staticmethod
-    def open(path, auto_embed=False, read_only=False, embed_batch_size=None,
-             embed_model=None):
+    def open(path, read_only=False):
         """Open a database at the given path.
+
+        Configuration (auto_embed, embed_model, embed_batch_size, etc.) is
+        managed via ``configure_set()`` / ``configure_get()`` and persisted
+        automatically in ``strata.toml``.
 
         Args:
             path: Directory path for the database.
-            auto_embed: Enable automatic text embedding for semantic search.
             read_only: Open in read-only mode.
-            embed_batch_size: Number of texts to batch for embedding (default 64).
-            embed_model: Embedding model name. One of ``"miniLM"`` (384d, default),
-                ``"nomic-embed"`` (768d), ``"bge-m3"`` (1024d), or ``"gemma-embed"`` (768d).
-                Changing after data is indexed requires re-indexing.
         """
-        return Strata(_Strata.open(path, auto_embed=auto_embed, read_only=read_only,
-                                   embed_batch_size=embed_batch_size,
-                                   embed_model=embed_model))
+        return Strata(_Strata.open(path, read_only=read_only))
 
     @staticmethod
     def cache():
@@ -732,13 +727,15 @@ class Strata:
     def configure_set(self, key, value):
         """Set a database configuration key.
 
-        Supported keys: ``"provider"`` (local/anthropic/openai/google),
-        ``"default_model"``, ``"anthropic_api_key"``, ``"openai_api_key"``,
-        ``"google_api_key"``, ``"embed_model"`` (miniLM/nomic-embed/bge-m3/gemma-embed).
+        Supported keys: ``"provider"``, ``"default_model"``,
+        ``"anthropic_api_key"``, ``"openai_api_key"``, ``"google_api_key"``,
+        ``"embed_model"``, ``"durability"``, ``"auto_embed"``, ``"bm25_k1"``,
+        ``"bm25_b"``, ``"embed_batch_size"``, ``"model_endpoint"``,
+        ``"model_name"``, ``"model_api_key"``, ``"model_timeout_ms"``.
 
         Args:
             key: Configuration key name.
-            value: Configuration value.
+            value: Configuration value (always a string).
         """
         self._inner.configure_set(key, value)
 

--- a/tests/test_strata.py
+++ b/tests/test_strata.py
@@ -1335,7 +1335,8 @@ class TestEmbedModel:
         db.set_embed_model("bge-m3")
         assert db.configure_get("provider") == "local"
 
-    def test_open_with_embed_model(self):
+    def test_open_then_set_embed_model(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            db = Strata.open(tmpdir, embed_model="nomic-embed")
+            db = Strata.open(tmpdir)
+            db.configure_set("embed_model", "nomic-embed")
             assert db.configure_get("embed_model") == "nomic-embed"


### PR DESCRIPTION
## Summary
- Remove `auto_embed`, `embed_batch_size`, `embed_model` params from `Strata.open()` — signature is now `open(path, read_only=False)`
- All configuration is managed via `configure_set()` / `configure_get()` and persisted in `strata.toml`
- Update docstrings to list all 15 supported config keys
- Update Cargo.lock to strata-core `5d73c8f` (unified config from strata-ai-labs/strata-core#1264)

## Test plan
- [x] All 180 Python tests pass
- [x] `cargo check` compiles clean
- [x] Test updated: `test_open_with_embed_model` → `test_open_then_set_embed_model` (uses `configure_set` after open)
- [x] Existing `configure_set()`, `configure_get()`, `set_auto_embed()`, `configure_model()` methods unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)