### PR TITLE
Fix db.json.history() AttributeError on existing documents

### DIFF
--- a/python/stratadb/namespaces/json.py
+++ b/python/stratadb/namespaces/json.py
@@ -154,7 +154,7 @@ class JSONNamespace(Namespace):
             True
         """
         result = self._c.json_history(key, **self._scope)
-        return result.items if result is not None else None
+        return list(result) if result is not None else None
 
     def count(self, prefix: Optional[str] = None, *, as_of: Optional[int] = None) -> int:
         """Number of documents, optionally under an id prefix.

--- a/tests/test_kv_json.py
+++ b/tests/test_kv_json.py
@@ -143,6 +143,14 @@ def test_json_time_travel(db):
     assert db.json.get("d", as_of=at) == {"v": 1}
 
 
+def test_json_history_and_miss(db):
+    db.json.set("d", "$", {"v": 1})
+    db.json.set("d", "$", {"v": 2})
+    history = db.json.history("d")
+    assert [item.value for item in history] == [{"v": 2}, {"v": 1}]
+    assert db.json.history("never") is None
+
+
 def test_state_namespace_still_reserved(db):
     with pytest.raises(errors.UnsupportedError):
         _ = db.state


### PR DESCRIPTION
Fixes #20.

`db.json.history(key)` currently unwraps `.items`, but the generated `json_history` command returns either `None` or a bare list of `JsonHistoryItem`. Existing documents therefore raise `AttributeError` while missing documents happen to work.

This returns the generated list directly and adds coverage alongside the existing KV and JSON namespace behavior tests. The regression covers both an existing document with newest-first history and an absent document returning `None`.

The focused pure-Python regression passes locally, and both changed files compile cleanly. The repository's full test suite requires its private native `strata-core` dependency and `STRATAHUB_READ_TOKEN`, so I could not run that native-backed suite locally.
